### PR TITLE
Add Docker workflow and ESLint config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 *.pyc
 .env
 inventory.db
+coverage/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,10 +9,11 @@
 ## 0. TL;DR for Agents
 1. Read this file start-to-finish **before** generating code.  
 2. Keep code inside its domain folder (see §2).  
-3. Code must pass `npm run lint && npm run test:unit` with zero warnings.  
-4. Use Conventional Commit messages (`feat:`, `fix:`, `chore:`, etc.).  
-5. Never edit `/infra/db/migrations/*` unless task explicitly says so.  
-6. Prefer small PRs (< 300 LOC changed) with screenshot/test evidence.
+3. Code must pass `npm run lint && npm run test:unit` with zero warnings.
+4. A task isn't complete unless these checks succeed.
+5. Use Conventional Commit messages (`feat:`, `fix:`, `chore:`, etc.).
+6. Never edit `/infra/db/migrations/*` unless task explicitly says so.
+7. Prefer small PRs (< 300 LOC changed) with screenshot/test evidence.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,5 @@ All notable changes to this project will be documented in this file.
 - Added `CHANGELOG.md` and updated development instructions.
 - Updated `AGENTS.md` to remind contributors to update this changelog.
 - Added GitHub Actions pipeline for lint and unit tests.
+- Added Dockerfiles, docker-compose and a Makefile for local container setup.
+- Fixed Makefile indentation to avoid errors when running `make`.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+DC=docker compose -f infra/docker/docker-compose.yml
+
+up:
+	$(DC) up --build
+
+down:
+	$(DC) down

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The API will start on `http://localhost:5000`.
 Install Node dependencies and start the dev server:
 
 ```bash
-npm install
+npm ci
 npm run dev
 ```
 
@@ -34,6 +34,16 @@ Build a production bundle with:
 ```bash
 npm run build
 ```
+
+## Docker Setup
+
+To run the entire stack using Docker:
+
+```bash
+make up
+```
+
+The frontend will be available at `http://localhost:3000` and the backend API at `http://localhost:5000`.
 
 ## Project Structure
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,16 @@
+/* eslint import/no-extraneous-dependencies: 0, no-underscore-dangle: 0 */
+import { FlatCompat } from '@eslint/eslintrc';
+import { fileURLToPath } from 'url';
+import path from 'path';
+import cjsConfig from './.eslintrc.cjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+export default [
+  ...compat.config(cjsConfig),
+  { ignores: ['node_modules', 'public'] },
+];

--- a/infra/docker/Dockerfile.backend
+++ b/infra/docker/Dockerfile.backend
@@ -1,0 +1,11 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 5000
+CMD ["python", "app.py"]

--- a/infra/docker/Dockerfile.frontend
+++ b/infra/docker/Dockerfile.frontend
@@ -1,0 +1,11 @@
+FROM node:18-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3.8'
+
+services:
+  backend:
+    build:
+      context: ../..
+      dockerfile: infra/docker/Dockerfile.backend
+    volumes:
+      - inventory-data:/app/inventory.db
+    ports:
+      - "5000:5000"
+
+  frontend:
+    build:
+      context: ../..
+      dockerfile: infra/docker/Dockerfile.frontend
+    ports:
+      - "3000:80"
+    depends_on:
+      - backend
+
+volumes:
+  inventory-data:


### PR DESCRIPTION
## Summary
- clarify tasks incomplete unless lint and tests pass in `AGENTS.md`
- document `npm ci` usage and Docker workflow in `README`
- add Makefile, Dockerfiles and compose for one-command startup
- ignore coverage output
- support ESLint 9 via flat config compatibility

## Testing
- `npm run lint`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_685ab84b83ec8327bb25bbb0e7dc7d70